### PR TITLE
feat: Add video to GIF converter

### DIFF
--- a/app/app.config.ts
+++ b/app/app.config.ts
@@ -16,6 +16,10 @@ export default defineAppConfig({
 			label: "Storage",
 			icon: "lucide:archive"
 		},
+		media: {
+			label: "Media",
+			icon: "lucide:film"
+		},
 		interface: {
 			label: "Interface",
 			icon: "lucide:app-window-mac"

--- a/app/pages/converter.vue
+++ b/app/pages/converter.vue
@@ -1,0 +1,95 @@
+<template>
+	<LayoutTile
+		title="Video Converter"
+		description="Convert mp4 files to gif."
+	>
+		<div class="space-y-6 md:space-y-8">
+			<div class="flex flex-col gap-y-4 items-start">
+				<UButton @click="selectFile" size="lg">
+					Select MP4 File
+				</UButton>
+				<p v-if="inputPath">Input file: {{ inputPath }}</p>
+				<p v-if="outputPath">Output file: {{ outputPath }}</p>
+			</div>
+
+			<UButton @click="convertFile" :disabled="!inputPath || !outputPath || loading" size="lg">
+				<span v-if="loading">Converting...</span>
+				<span v-else>Convert to GIF</span>
+			</UButton>
+		</div>
+	</LayoutTile>
+</template>
+
+<script lang="ts" setup>
+import { ref } from 'vue';
+import { open, save } from '@tauri-apps/api/dialog';
+import { invoke } from '@tauri-apps/api/tauri';
+
+definePageMeta({
+	name: "Converter",
+	icon: "lucide:film",
+	description: "Convert mp4 to gif",
+	category: "media"
+});
+
+const inputPath = ref<string | null>(null);
+const outputPath = ref<string | null>(null);
+const loading = ref(false);
+const toast = useToast();
+
+const selectFile = async () => {
+	const selected = await open({
+		multiple: false,
+		filters: [{
+			name: 'Video',
+			extensions: ['mp4']
+		}]
+	});
+
+	if (typeof selected === 'string') {
+		inputPath.value = selected;
+		// Suggest output path
+		outputPath.value = selected.replace(/\.mp4$/, '.gif');
+	}
+};
+
+const convertFile = async () => {
+	if (!inputPath.value || !outputPath.value) {
+		return;
+	}
+
+	const savePath = await save({
+		defaultPath: outputPath.value,
+		filters: [{
+			name: 'GIF',
+			extensions: ['gif']
+		}]
+	});
+
+	if (!savePath) {
+		return;
+	}
+	outputPath.value = savePath;
+
+	loading.value = true;
+	try {
+		await invoke('convert_to_gif', {
+			inputPath: inputPath.value,
+			outputPath: outputPath.value
+		});
+		toast.add({
+			title: 'Success',
+			description: 'File converted successfully!',
+			color: 'success'
+		});
+	} catch (error) {
+		toast.add({
+			title: 'Error',
+			description: String(error),
+			color: 'error'
+		});
+	} finally {
+		loading.value = false;
+	}
+};
+</script>

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2174,7 +2174,7 @@ dependencies = [
 
 [[package]]
 name = "nuxtor"
-version = "1.3.1"
+version = "1.4.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,6 +4,27 @@ use tauri::{
 	menu::{Menu, MenuItem},
 	tray::TrayIconBuilder
 };
+use std::process::Command;
+
+#[tauri::command]
+async fn convert_to_gif(input_path: String, output_path: String) -> Result<(), String> {
+    let output = Command::new("ffmpeg")
+        .arg("-i")
+        .arg(&input_path)
+        .arg(&output_path)
+        .output();
+
+    match output {
+        Ok(output) => {
+            if output.status.success() {
+                Ok(())
+            } else {
+                Err(String::from_utf8_lossy(&output.stderr).to_string())
+            }
+        }
+        Err(e) => Err(e.to_string()),
+    }
+}
 
 pub fn run() {
     tauri::Builder::default()
@@ -32,6 +53,7 @@ pub fn run() {
 		.plugin(tauri_plugin_os::init())
 		.plugin(tauri_plugin_fs::init())
 		.plugin(tauri_plugin_store::Builder::new().build())
+		.invoke_handler(tauri::generate_handler![convert_to_gif])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }


### PR DESCRIPTION
This commit adds a new feature to the application that allows you to convert MP4 videos to GIFs.

The implementation includes:
- A new Tauri command `convert_to_gif` in the Rust backend that uses `ffmpeg` to perform the conversion.
- A new Vue component `converter.vue` that provides a user interface for selecting an MP4 file and a destination for the output GIF.
- An update to the application's configuration to add a "Media" category to the sidebar, making the new converter page accessible.
- Installation of necessary system dependencies like `ffmpeg` and `libwebkit2gtk-4.1-dev`.