### PR TITLE
Fix Nuxt stalling due to host ip

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -72,7 +72,7 @@ export default defineNuxtConfig({
 		}
 	},
 	devServer: {
-		host: host || "0"
+		host: host || "0.0.0.0"
 	},
 	router: {
 		options: {


### PR DESCRIPTION
Nuxt was unable to open a port on host '0' on windows.